### PR TITLE
updated logout test to use .get() method instead of brackets

### DIFF
--- a/server/testing/app_testing/app_test.py
+++ b/server/testing/app_testing/app_test.py
@@ -210,7 +210,7 @@ class TestLogout:
             # check if logged out
             client.delete('/logout')
             with client.session_transaction() as session:
-                assert not session['user_id']
+                assert not session.get('user_id')
             
     def test_401s_if_no_session(self):
         '''returns 401 if a user attempts to logout without a session at /logout.'''


### PR DESCRIPTION
accessing keys on dictionary with brackets throws KeyError - using .get() returns None

We're attempting to use falsy control flow logic on this line of our test file, but the approach we're currently using is actually triggering a key error when the key isn't present, which crashes the tests. We want the key to be absent at this point, so this is preventing students from effectively passing these tests.