### PR TITLE
Tweak tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Add database constraints for the `Recipe` model:
 Your `Recipe` model should also:
 
 - constrain the `title` to be present.
-- constrain the `instructions` to be present and at least 50 characters long.
+- constrain the `instructions` to be present and at least 50 characters long, 
+alternately you may use a custom validation.
 
 Run the migrations after creating your models. You'll need to run
 `flask db init` before running `flask db revision autogenerate` or

--- a/server/models.py
+++ b/server/models.py
@@ -1,3 +1,4 @@
+from sqlalchemy.orm import validates
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy_serializer import SerializerMixin
 

--- a/server/testing/app_testing/app_test.py
+++ b/server/testing/app_testing/app_test.py
@@ -210,7 +210,7 @@ class TestLogout:
             # check if logged out
             client.delete('/logout')
             with client.session_transaction() as session:
-                assert not session['user_id']
+                assert not session.get('user_id')
             
     def test_401s_if_no_session(self):
         '''returns 401 if a user attempts to logout without a session at /logout.'''

--- a/server/testing/models_testing/recipe_test.py
+++ b/server/testing/models_testing/recipe_test.py
@@ -64,11 +64,11 @@ class TestRecipe:
             Recipe.query.delete()
             db.session.commit()
 
-            recipe = Recipe(
-                title="Generic Ham",
-                instructions="idk lol")
-
-            with pytest.raises(IntegrityError):
+            '''must raise either a sqlalchemy.exc.IntegrityError with constraints or a custom validation ValueError'''
+            with pytest.raises( (IntegrityError, ValueError) ):
+                recipe = Recipe(
+                    title="Generic Ham",
+                    instructions="idk lol")
                 db.session.add(recipe)
                 db.session.commit()
 


### PR DESCRIPTION
1. Currently the database constraint for a minimum character count on recipe.instructions isn't in the curriculum (to my knowledge) and the provided solution only works unreliably for students. Added in code so students can solve it with a validates ValueError as well and updated the readme accordingly.
2. Changed the logout test so that it accounts for session.pop rather than just setting cookie values to None. This should allow students who learned session.pop in class to pass the test.